### PR TITLE
fix #75 - change chrome publish to new widget directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules
 /firefox
 /chrome
 README.html
+/prod
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,10 +99,9 @@ gulp.task('strip-debug',['chrome-coffee'],function () {
 })
 
 gulp.task('publish-chrome',['strip-debug'],function () {
-  manifest = src('./src/chrome/manifest.json')
+  manifest = gulp.src('./src/chrome/manifest.json')
   others = gulp.src([
-    'img/*',
-    'js/*.js',
+    'static/js/*.js'
   ], { base : "."})
       
   merge (manifest,others)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,15 +8,21 @@ var merge = require('merge-stream');
 var zip = require('gulp-zip');
 var jeditor = require("gulp-json-editor");
 var shell = require('gulp-shell');
+var rename = require('gulp-rename')
 
 dev_domain  = "127.0.0.1"
 dev_port = '8443'
 
-gulp.task('chrome-coffee', function(event) {
+
+compile_chrome = function (event) {
   return gulp.src(['./src/chrome/*.coffee','./src/*.coffee'])
     .pipe(coffee({bare: true}).on('error', gutil.log))
-    .pipe(gulp.dest('./chrome/js'))
+};
+
+gulp.task('chrome-coffee', function(event) {
+    compile_chrome().pipe(gulp.dest('./chrome/js'))
 });
+
 
 gulp.task('firefox-coffee', function(event) {
   return gulp.src(['./src/firefox/*.coffee','./src/*.coffee'])
@@ -86,25 +92,17 @@ gulp.task('dev-firefox',['load-static','firefox-package','firefox-coffee'],funct
 gulp.task('dev',['dev-chrome','dev-firefox'])
 
 
-gulp.task('go-ff',function () {
-    shell.task(['echo howdy','echo world'])  
-})
-
 // publish related tasks
-
-gulp.task('strip-debug',['chrome-coffee'],function () {
-  return gulp.src('js/*.js')
-    .pipe(stripDebug())
-    .pipe(gulp.dest('js/'))
-})
-
-gulp.task('publish-chrome',['strip-debug'],function () {
+gulp.task('publish-chrome', function () {
   manifest = gulp.src('./src/chrome/manifest.json')
-  others = gulp.src([
-    'static/js/*.js'
-  ], { base : "."})
+  clean_js = compile_chrome()
+    .pipe(stripDebug())   
+    .pipe(rename(function (path) {
+      path.dirname += "/js";
+    }))
+  static_files = gulp.src(['static/js/*.js'], { base : "./static"})
       
-  merge (manifest,others)
+  merge (manifest,clean_js,static_files)
     .pipe(zip('codesy.zip'))
     .pipe(gulp.dest('prod'));
   

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "gulp": "^3.8.6", 
         "gulp-coffee": "2.3.1",
         "gulp-json-editor": "2.2.1",
+        "gulp-rename": "^1.2.0",
         "gulp-shell" : "0.2.11",
         "gulp-sourcemaps": "1.5.0",
         "gulp-strip-debug": "1.0.2",


### PR DESCRIPTION
-fixed line that left off 'gulp.'
-removed imgs since the chrome widget gets images from codesy.io
-fixed directory to point to 'static/js' 