### PR TITLE
fix chrome static with single static function

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ combine_js = function (target) {
   console.log("compile "+target+" coffee files")
   return gulp.src(['./src/'+target+'/*.coffee','./src/*.coffee'])
     .pipe(coffee({bare: true}).on('error', gutil.log))
+
 };
 
 static_stream = function(){
@@ -30,17 +31,17 @@ gulp.task('chrome-coffee', function() {
 
 
 gulp.task('firefox-coffee', function(cb) {
+  
   return combine_js("firefox").pipe(gulp.dest('./firefox/js'))
 
 });
 
-gulp.task('chrome-static',function (cb) {
-  static_files = static_stream()
-  static_files.pipe(gulp.dest('chrome'))
+gulp.task('chrome-static',function () {
+   return static_stream().pipe(gulp.dest('chrome'))
 })
 
 gulp.task('firefox-static',function (cb) {
-  return gulp.src (['css/*','js/*.js','img/*.png'],{ base: "./static", cwd : "./static"}).pipe(gulp.dest('firefox')) 
+  return static_stream().pipe(gulp.dest('firefox')) 
 })
 
 
@@ -89,12 +90,13 @@ gulp.task('firefox-manifest', function() {
 
 
 gulp.task('dev-chrome',['chrome-static','chrome-manifest','chrome-coffee'],function () {
-    console.log("start watching")
+    console.log("start watching src/chrome")
     gulp.watch('./src/chrome/manifest.json',['chrome-manifest'])
     gulp.watch(['./src/chrome/*.coffee','./src/*.coffee'],['chrome-coffee'])
 })
 
 gulp.task('dev-firefox',['firefox-xpi'],function () {
+    console.log("start watching src/firefox")
     gulp.watch('./src/firefox/manifest.json',['firefox-xpi'])
     gulp.watch(['./src/firefox/*.coffee','./src/*.coffee'],['firefox-xpi'])  
 })
@@ -136,6 +138,7 @@ gulp.task('publish-chrome', function () {
     .pipe(rename(function (path) {
       path.dirname += "/js";
     }))
+    
   static_files = gulp.src(['static/js/*.js'], { base : "./static"})
       
   merge (manifest,clean_js,static_files)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,30 +21,32 @@ combine_js = function (target) {
 
 };
 
-static_stream = function(){
-  return gulp.src (['css/*','js/*.js','img/*.png'],{ base: "./static", cwd : "./static"})
+// ninja foo funtion to return function based on destination directory
+static_stream = function(dest) {
+  this.dest = dest
+  return (
+    function(_this) {
+      return function() {
+        return gulp.src(['css/*', 'js/*.js', 'img/*.png'], {
+          base: "./static",
+          cwd: "./static"
+        }).pipe(gulp.dest('./' + _this.dest + '/js'))
+      }
+    }
+  )(this)
 }
+
+gulp.task('chrome-static', static_stream("chrome"))
+
+gulp.task('firefox-static',static_stream("firefox"))
 
 gulp.task('chrome-coffee', function() {
   combine_js("chrome").pipe(gulp.dest('./chrome/js'))
 });
 
-
-gulp.task('firefox-coffee', function(cb) {
-  
+gulp.task('firefox-coffee', function() {
   return combine_js("firefox").pipe(gulp.dest('./firefox/js'))
-
 });
-
-gulp.task('chrome-static',function () {
-   return static_stream().pipe(gulp.dest('chrome'))
-})
-
-gulp.task('firefox-static',function (cb) {
-  return static_stream().pipe(gulp.dest('firefox')) 
-})
-
-
 
 gulp.task('chrome-manifest', function() {
   var manifest = JSON.parse(fs.readFileSync('./src/chrome/manifest.json'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,15 +30,15 @@ static_stream = function(dest) {
         return gulp.src(['css/*', 'js/*.js', 'img/*.png'], {
           base: "./static",
           cwd: "./static"
-        }).pipe(gulp.dest('./' + _this.dest + '/js'))
+        }).pipe(gulp.dest('./' + _this.dest ))
       }
     }
   )(this)
 }
 
-gulp.task('chrome-static', static_stream("chrome"))
+gulp.task('chrome-static', new static_stream("chrome"))
 
-gulp.task('firefox-static',static_stream("firefox"))
+gulp.task('firefox-static',new static_stream("firefox"))
 
 gulp.task('chrome-coffee', function() {
   combine_js("chrome").pipe(gulp.dest('./chrome/js'))


### PR DESCRIPTION
#81 was caused by a bug in the chrome-static task.  Refactored the functions for collecting the static file so that static-chrome and static-firefox are the same. 